### PR TITLE
[13.0][ADD]planned_quantity_field_in_mo

### DIFF
--- a/custom-addons/esb/mrp/models/mrp_production.py
+++ b/custom-addons/esb/mrp/models/mrp_production.py
@@ -30,6 +30,10 @@ class MrpProduction(models.Model):
     )
 
     mo_created = fields.Boolean(default=False)
+    planned_quantity = fields.Float(
+        string="Planned Quantity",
+        readonly=False,
+    )
 
     @api.model
     def create(self, vals):

--- a/custom-addons/esb/mrp/views/mrp_production_views.xml
+++ b/custom-addons/esb/mrp/views/mrp_production_views.xml
@@ -26,6 +26,9 @@
             <xpath expr="//field[@name='move_raw_ids']" position="after">
                 <field name="remark" class="oe_inline" placeholder="Remark ..."/>
             </xpath>
+            <xpath expr="//field[@name='bom_id']" position="before">
+                <field name="planned_quantity"/>
+            </xpath>
         </field>
     </record>
     <!-- Manufacturing Order Search -->


### PR DESCRIPTION
Add planned quantity field in manufacturing order.
![Screenshot from 2020-09-09 11-09-12](https://user-images.githubusercontent.com/66471051/92553512-4a5ada00-f28d-11ea-8c03-47e051b78b61.png)

cc. @newtratip 